### PR TITLE
Add rank to a template card to make validation pass

### DIFF
--- a/.cards/local/templates/processDescription/c/base_ecdl1c2j/index.json
+++ b/.cards/local/templates/processDescription/c/base_ecdl1c2j/index.json
@@ -6,5 +6,7 @@
     "base/fieldTypes/informationClassification": "internal",
     "base/fieldTypes/approver": null,
     "base/fieldTypes/approvalDate": null,
-    "base/fieldTypes/reviewPeriod": 365
+    "base/fieldTypes/reviewPeriod": 365,
+    "rank": "0|a",
+    "lastUpdated": "2024-11-18T17:51:50.694Z"
 }


### PR DESCRIPTION
Add rank to one template card.
After the changes, there are no validation errors from `module-base`.

FYI. @suvikaartinen when this is merged, it might be a good idea to "remove&&import" `module-base` again to `cyberismo-isms`.