### PR TITLE
Add copyright comments to calculation files

### DIFF
--- a/.cards/local/calculations/adoptionStep.lp
+++ b/.cards/local/calculations/adoptionStep.lp
@@ -1,3 +1,11 @@
+% Copyright © Cyberismo Ltd and contributors 2025
+%
+% License: https://github.com/CyberismoCom/module-base/blob/main/LICENSE
+% The use of the Cyberismo trademark: https://cyberismo.com/trademark-policy/
+% This content is distributed in the hope that it will be useful, but
+% WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+% FITNESS FOR A PARTICULAR PURPOSE.
+
 base_greaterAdoptionStep(Card1, Card2) :-
     field(Card1, "base/fieldTypes/adoptionStep", "step1"),
     card(Card2),

--- a/.cards/local/calculations/documentControl.lp
+++ b/.cards/local/calculations/documentControl.lp
@@ -1,3 +1,11 @@
+% Copyright © Cyberismo Ltd and contributors 2025
+%
+% License: https://github.com/CyberismoCom/module-base/blob/main/LICENSE
+% The use of the Cyberismo trademark: https://cyberismo.com/trademark-policy/
+% This content is distributed in the hope that it will be useful, but
+% WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+% FITNESS FOR A PARTICULAR PURPOSE.
+
 transitionDenied(Document, "Approve", "Fix policy failures before approving" ):-
     field(Document, "cardType", "base/cardTypes/controlledDocument"),
     policyCheckFailure(Document, _, _, _).

--- a/.cards/local/calculations/lastReviewed.lp
+++ b/.cards/local/calculations/lastReviewed.lp
@@ -1,3 +1,10 @@
+% Copyright © Cyberismo Ltd and contributors 2025
+%
+% License: https://github.com/CyberismoCom/module-base/blob/main/LICENSE
+% The use of the Cyberismo trademark: https://cyberismo.com/trademark-policy/
+% This content is distributed in the hope that it will be useful, but
+% WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+% FITNESS FOR A PARTICULAR PURPOSE.
 
 % base/workflows/review
 onTransitionSetField(Card, "Mark as passed", Card, "base/fieldTypes/lastReviewed", @today()) :-

--- a/.cards/local/calculations/meetingMemoTitle.lp
+++ b/.cards/local/calculations/meetingMemoTitle.lp
@@ -1,3 +1,11 @@
+% Copyright © Cyberismo Ltd and contributors 2025
+%
+% License: https://github.com/CyberismoCom/module-base/blob/main/LICENSE
+% The use of the Cyberismo trademark: https://cyberismo.com/trademark-policy/
+% This content is distributed in the hope that it will be useful, but
+% WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+% FITNESS FOR A PARTICULAR PURPOSE.
+
 onTransitionSetField(Card, "Create", Card, "title", @concatenate(@today(), " Untitled meeting notes")) :-
     field(Card, "cardType", "base/cardTypes/page"),
     field(Card, "title", "Untitled meeting notes").

--- a/.cards/local/calculations/policyCheckFailure.lp
+++ b/.cards/local/calculations/policyCheckFailure.lp
@@ -1,3 +1,11 @@
+% Copyright © Cyberismo Ltd and contributors 2025
+%
+% License: https://github.com/CyberismoCom/module-base/blob/main/LICENSE
+% The use of the Cyberismo trademark: https://cyberismo.com/trademark-policy/
+% This content is distributed in the hope that it will be useful, but
+% WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+% FITNESS FOR A PARTICULAR PURPOSE.
+
 % a helper term for finding failures regardless of they have a field or not
 base_policyCheckFailure(Card, Category, Title, Message) :-
     policyCheckFailure(Card, Category, Title, Message).

--- a/.cards/local/calculations/statusIndicator.lp
+++ b/.cards/local/calculations/statusIndicator.lp
@@ -1,3 +1,11 @@
+% Copyright © Cyberismo Ltd and contributors 2025
+%
+% License: https://github.com/CyberismoCom/module-base/blob/main/LICENSE
+% The use of the Cyberismo trademark: https://cyberismo.com/trademark-policy/
+% This content is distributed in the hope that it will be useful, but
+% WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+% FITNESS FOR A PARTICULAR PURPOSE.
+
 field(Card, "statusIndicator", "error") :-
     base_policyCheckFailure(Card, _, _, _),
     not base_disableDefaultStatusIndicator.


### PR DESCRIPTION
Add copyright comment blocks to calculation files.

The link in the copyright points to https://github.com/CyberismoCom/module-base/blob/main/LICENSE which is a valid link for this repository.