### PR TITLE
INTDEV-730 Ensure that each resource has 'displayName' and 'description'

### DIFF
--- a/.cards/local/cardTypes/annualTask.json
+++ b/.cards/local/cardTypes/annualTask.json
@@ -35,5 +35,6 @@
         "base/fieldTypes/informationClassification",
         "base/fieldTypes/justification",
         "base/fieldTypes/reviewMonth"
-    ]
+    ],
+    "displayName": ""
 }

--- a/.cards/local/cardTypes/controlledDocument.json
+++ b/.cards/local/cardTypes/controlledDocument.json
@@ -22,5 +22,6 @@
     ],
     "optionallyVisibleFields": [
         "base/fieldTypes/informationClassification"
-    ]
+    ],
+    "displayName": ""
 }

--- a/.cards/local/cardTypes/decision.json
+++ b/.cards/local/cardTypes/decision.json
@@ -18,5 +18,6 @@
     ],
     "optionallyVisibleFields": [
         "base/fieldTypes/informationClassification"
-    ]
+    ],
+    "displayName": ""
 }

--- a/.cards/local/cardTypes/monthlyTask.json
+++ b/.cards/local/cardTypes/monthlyTask.json
@@ -31,5 +31,6 @@
     "optionallyVisibleFields": [
         "base/fieldTypes/justification",
         "base/fieldTypes/informationClassification"
-    ]
+    ],
+    "displayName": ""
 }

--- a/.cards/local/cardTypes/page.json
+++ b/.cards/local/cardTypes/page.json
@@ -14,5 +14,6 @@
     ],
     "optionallyVisibleFields": [
         "base/fieldTypes/informationClassification"
-    ]
+    ],
+    "displayName": ""
 }

--- a/.cards/local/cardTypes/quarterlyTask.json
+++ b/.cards/local/cardTypes/quarterlyTask.json
@@ -35,5 +35,6 @@
         "base/fieldTypes/justification",
         "base/fieldTypes/quarterlyReviewMonth",
         "base/fieldTypes/informationClassification"
-    ]
+    ],
+    "displayName": ""
 }

--- a/.cards/local/cardTypes/review.json
+++ b/.cards/local/cardTypes/review.json
@@ -22,5 +22,6 @@
     "optionallyVisibleFields": [
         "base/fieldTypes/reviewPeriod",
         "base/fieldTypes/informationClassification"
-    ]
+    ],
+    "displayName": ""
 }

--- a/.cards/local/cardTypes/reviewTask.json
+++ b/.cards/local/cardTypes/reviewTask.json
@@ -32,5 +32,6 @@
         "base/fieldTypes/justification",
         "base/fieldTypes/reviewPeriod",
         "base/fieldTypes/informationClassification"
-    ]
+    ],
+    "displayName": ""
 }

--- a/.cards/local/cardTypes/roleAssignment.json
+++ b/.cards/local/cardTypes/roleAssignment.json
@@ -14,5 +14,6 @@
     ],
     "optionallyVisibleFields": [
         "base/fieldTypes/informationClassification"
-    ]
+    ],
+    "displayName": ""
 }

--- a/.cards/local/cardTypes/task.json
+++ b/.cards/local/cardTypes/task.json
@@ -28,5 +28,6 @@
     "optionallyVisibleFields": [
         "base/fieldTypes/justification",
         "base/fieldTypes/informationClassification"
-    ]
+    ],
+    "displayName": ""
 }

--- a/.cards/local/fieldTypes/identifier.json
+++ b/.cards/local/fieldTypes/identifier.json
@@ -1,6 +1,6 @@
 {
     "name": "base/fieldTypes/identifier",
     "displayName": "Identifier",
-    "fieldDescription": "An identifier for creating various mappings between cards",
-    "dataType": "shortText"
+    "dataType": "shortText",
+    "description": "An identifier for creating various mappings between cards"
 }

--- a/.cards/local/fieldTypes/justification.json
+++ b/.cards/local/fieldTypes/justification.json
@@ -1,6 +1,6 @@
 {
     "name": "base/fieldTypes/justification",
     "displayName": "Justification",
-    "fieldDescription": "Justification for why this card is not applicable",
-    "dataType": "longText"
+    "dataType": "longText",
+    "description": "Justification for why this card is not applicable"
 }

--- a/.cards/local/fieldTypes/progress.json
+++ b/.cards/local/fieldTypes/progress.json
@@ -1,6 +1,6 @@
 {
     "name": "base/fieldTypes/progress",
     "displayName": "Progress",
-    "fieldDescription": "A progress metric",
-    "dataType": "integer"
+    "dataType": "integer",
+    "description": "A progress metric"
 }

--- a/.cards/local/fieldTypes/quarterlyReviewMonth.json
+++ b/.cards/local/fieldTypes/quarterlyReviewMonth.json
@@ -1,7 +1,6 @@
 {
     "name": "base/fieldTypes/quarterlyReviewMonth",
     "displayName": "Quarterly review month",
-    "fieldDescription": "The month in each quarter in which this task should be revisited.",
     "dataType": "enum",
     "enumValues": [
         {
@@ -16,5 +15,6 @@
             "enumValue": "month3",
             "enumDisplayValue": "Month 3"
         }
-    ]
+    ],
+    "description": "The month in each quarter in which this task should be revisited."
 }

--- a/.cards/local/fieldTypes/reviewMonth.json
+++ b/.cards/local/fieldTypes/reviewMonth.json
@@ -1,7 +1,6 @@
 {
     "name": "base/fieldTypes/reviewMonth",
     "displayName": "Review month",
-    "fieldDescription": "The month in which this task should be revisited.",
     "dataType": "enum",
     "enumValues": [
         {
@@ -52,5 +51,6 @@
             "enumValue": "december",
             "enumDisplayValue": "December"
         }
-    ]
+    ],
+    "description": "The month in which this task should be revisited."
 }

--- a/.cards/local/linkTypes/blocks.json
+++ b/.cards/local/linkTypes/blocks.json
@@ -4,5 +4,6 @@
     "inboundDisplayName": "is blocked by",
     "sourceCardTypes": [],
     "destinationCardTypes": [],
-    "enableLinkDescription": false
+    "enableLinkDescription": false,
+    "displayName": ""
 }

--- a/.cards/local/linkTypes/relatesTo.json
+++ b/.cards/local/linkTypes/relatesTo.json
@@ -4,5 +4,6 @@
     "inboundDisplayName": "is related to",
     "sourceCardTypes": [],
     "destinationCardTypes": [],
-    "enableLinkDescription": false
+    "enableLinkDescription": false,
+    "displayName": ""
 }

--- a/.cards/local/linkTypes/supersedes.json
+++ b/.cards/local/linkTypes/supersedes.json
@@ -2,7 +2,12 @@
     "name": "base/linkTypes/supersedes",
     "outboundDisplayName": "supersedes",
     "inboundDisplayName": "is superseded by",
-    "sourceCardTypes": ["base/cardTypes/decision"],
-    "destinationCardTypes": ["base/cardTypes/decision"],
-    "enableLinkDescription": false
+    "sourceCardTypes": [
+        "base/cardTypes/decision"
+    ],
+    "destinationCardTypes": [
+        "base/cardTypes/decision"
+    ],
+    "enableLinkDescription": false,
+    "displayName": ""
 }

--- a/.cards/local/workflows/controlledDocument.json
+++ b/.cards/local/workflows/controlledDocument.json
@@ -1,9 +1,18 @@
 {
     "name": "base/workflows/controlledDocument",
     "states": [
-        { "name": "Draft", "category": "initial" },
-        { "name": "Approved", "category": "closed" },
-        { "name": "Archived", "category": "closed" }
+        {
+            "name": "Draft",
+            "category": "initial"
+        },
+        {
+            "name": "Approved",
+            "category": "closed"
+        },
+        {
+            "name": "Archived",
+            "category": "closed"
+        }
     ],
     "transitions": [
         {
@@ -13,18 +22,25 @@
         },
         {
             "name": "Approve",
-            "fromState": ["Draft"],
+            "fromState": [
+                "Draft"
+            ],
             "toState": "Approved"
         },
         {
             "name": "Archive",
-            "fromState": ["*"],
+            "fromState": [
+                "*"
+            ],
             "toState": "Archived"
         },
         {
             "name": "Reopen",
-            "fromState": ["*"],
+            "fromState": [
+                "*"
+            ],
             "toState": "Draft"
         }
-    ]
+    ],
+    "displayName": ""
 }

--- a/.cards/local/workflows/decision.json
+++ b/.cards/local/workflows/decision.json
@@ -17,23 +17,32 @@
     "transitions": [
         {
             "name": "Create",
-            "fromState": [""],
+            "fromState": [
+                ""
+            ],
             "toState": "Draft"
         },
         {
             "name": "Approve",
-            "fromState": ["Draft"],
+            "fromState": [
+                "Draft"
+            ],
             "toState": "Approved"
         },
         {
             "name": "Archive",
-            "fromState": ["*"],
+            "fromState": [
+                "*"
+            ],
             "toState": "Deprecated"
         },
         {
             "name": "Reopen",
-            "fromState": ["*"],
+            "fromState": [
+                "*"
+            ],
             "toState": "Draft"
         }
-    ]
+    ],
+    "displayName": ""
 }

--- a/.cards/local/workflows/page.json
+++ b/.cards/local/workflows/page.json
@@ -2,13 +2,16 @@
     "name": "base/workflows/page",
     "states": [
         {
-            "name": "Draft", "category": "initial"
+            "name": "Draft",
+            "category": "initial"
         },
         {
-            "name": "Ready", "category": "closed"
+            "name": "Ready",
+            "category": "closed"
         },
         {
-            "name": "Deprecated", "category": "closed"
+            "name": "Deprecated",
+            "category": "closed"
         }
     ],
     "transitions": [
@@ -19,18 +22,25 @@
         },
         {
             "name": "Content ready",
-            "fromState": ["Draft"],
+            "fromState": [
+                "Draft"
+            ],
             "toState": "Ready"
         },
         {
             "name": "Archive",
-            "fromState": ["*"],
+            "fromState": [
+                "*"
+            ],
             "toState": "Deprecated"
         },
         {
             "name": "Reopen",
-            "fromState": ["*"],
+            "fromState": [
+                "*"
+            ],
             "toState": "Draft"
         }
-    ]
+    ],
+    "displayName": ""
 }

--- a/.cards/local/workflows/recurringTask.json
+++ b/.cards/local/workflows/recurringTask.json
@@ -25,38 +25,56 @@
     "transitions": [
         {
             "name": "Create",
-            "fromState": [""],
+            "fromState": [
+                ""
+            ],
             "toState": "Open"
         },
         {
             "name": "Reopen",
-            "fromState": ["*"],
+            "fromState": [
+                "*"
+            ],
             "toState": "Open"
         },
         {
             "name": "Review as applicable",
-            "fromState": ["Open", "Closed as not applicable"],
+            "fromState": [
+                "Open",
+                "Closed as not applicable"
+            ],
             "toState": "To do"
         },
         {
             "name": "Start progress",
-            "fromState": ["To do"],
+            "fromState": [
+                "To do"
+            ],
             "toState": "In progress"
         },
         {
             "name": "Done",
-            "fromState": ["Open", "To do", "In progress"],
+            "fromState": [
+                "Open",
+                "To do",
+                "In progress"
+            ],
             "toState": "Closed as done"
         },
         {
             "name": "Review as OK",
-            "fromState": ["Closed as done"],
+            "fromState": [
+                "Closed as done"
+            ],
             "toState": "Closed as done"
         },
         {
             "name": "Review as not applicable",
-            "fromState": ["*"],
+            "fromState": [
+                "*"
+            ],
             "toState": "Closed as not applicable"
         }
-    ]
+    ],
+    "displayName": ""
 }

--- a/.cards/local/workflows/review.json
+++ b/.cards/local/workflows/review.json
@@ -46,5 +46,6 @@
             ],
             "toState": "Draft"
         }
-    ]
+    ],
+    "displayName": ""
 }

--- a/.cards/local/workflows/reviewTask.json
+++ b/.cards/local/workflows/reviewTask.json
@@ -25,38 +25,54 @@
     "transitions": [
         {
             "name": "Create",
-            "fromState": [""],
+            "fromState": [
+                ""
+            ],
             "toState": "Open"
         },
         {
             "name": "Reopen",
-            "fromState": ["*"],
+            "fromState": [
+                "*"
+            ],
             "toState": "Open"
         },
         {
             "name": "Start progress",
-            "fromState": ["Open"],
+            "fromState": [
+                "Open"
+            ],
             "toState": "In progress"
         },
         {
             "name": "Require changes",
-            "fromState": ["*"],
+            "fromState": [
+                "*"
+            ],
             "toState": "Changes required"
         },
         {
             "name": "Done",
-            "fromState": ["In progress", "Changes required"],
+            "fromState": [
+                "In progress",
+                "Changes required"
+            ],
             "toState": "Closed as done"
         },
         {
             "name": "Review as OK",
-            "fromState": ["Closed as done"],
+            "fromState": [
+                "Closed as done"
+            ],
             "toState": "Closed as done"
         },
         {
             "name": "Review as not applicable",
-            "fromState": ["*"],
+            "fromState": [
+                "*"
+            ],
             "toState": "Closed as not applicable"
         }
-    ]
+    ],
+    "displayName": ""
 }

--- a/.cards/local/workflows/roleAssignment.json
+++ b/.cards/local/workflows/roleAssignment.json
@@ -36,5 +36,6 @@
             ],
             "toState": "Archived"
         }
-    ]
+    ],
+    "displayName": ""
 }

--- a/.cards/local/workflows/task.json
+++ b/.cards/local/workflows/task.json
@@ -21,28 +21,40 @@
     "transitions": [
         {
             "name": "Create",
-            "fromState": [""],
+            "fromState": [
+                ""
+            ],
             "toState": "Open"
         },
         {
             "name": "Reopen",
-            "fromState": ["*"],
+            "fromState": [
+                "*"
+            ],
             "toState": "Open"
         },
         {
             "name": "Start progress",
-            "fromState": ["Open"],
+            "fromState": [
+                "Open"
+            ],
             "toState": "In progress"
         },
         {
             "name": "Done",
-            "fromState": ["In progress"],
+            "fromState": [
+                "In progress"
+            ],
             "toState": "Closed as done"
         },
         {
             "name": "Review as not applicable",
-            "fromState": ["Open", "In progress"],
+            "fromState": [
+                "Open",
+                "In progress"
+            ],
             "toState": "Closed as not applicable"
         }
-    ]
+    ],
+    "displayName": ""
 }


### PR DESCRIPTION
As highlighted in the JIRA ticker [INTDEV-730](https://cyberismo.atlassian.net/browse/INTDEV-730?atlOrigin=eyJpIjoiNmU0OTU1MjA0OWM0NGY0ODhkNDJhOWQzMjBiMzFjMGYiLCJwIjoiaiJ9), all resources shall have
- description (string; optional)
- displayName (string; mandatory)

The required changes are highlighted in the JIRA ticket.

- Adding all required `displayNames`. 
- For Field Types, `fieldDescription` is changed to `description`. Existing values are used even though key name changes.
- If reviewers have good display names for the resources, I am more than happy to set them to correct values in this PR. 
Currently, all resource display names are just empty.

This PR must be merged before the actual code change (ref https://github.com/CyberismoCom/cyberismo/pull/675) since tests for code changes depend on this repo (which is WRONG, but that's how it currently is).

This migrator application can be used to migrate changes for any repository. 
Usage `node migrator.js <path-to-project-to-migrate>`
[migrate_resources_display_name_and_description.zip](https://github.com/user-attachments/files/20385210/migrate_resources_display_name_and_description.zip)
